### PR TITLE
feat(ci): date-tagged images, GitHub releases, weekly submodule update PRs

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -5,9 +5,15 @@ on:
     branches:
       - main
   schedule:
-    # Weekly build every Monday 06:00 UTC — picks up upstream submodule changes
+    # Weekly build every Monday 06:00 UTC — rebuilds images pinned to current submodule SHAs in main.
+    # To pull in new upstream commits, merge the PR from update-submodules.yml first.
     - cron: '0 6 * * 1'
   workflow_dispatch:
+
+# Prevent concurrent builds on the same ref; cancel any in-progress run.
+concurrency:
+  group: build-images-${{ github.ref }}
+  cancel-in-progress: true
 
 env:
   REGISTRY: ghcr.io
@@ -20,8 +26,6 @@ jobs:
     permissions:
       contents: read
       packages: write
-    outputs:
-      date_tag: ${{ steps.meta.outputs.date_tag }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -91,6 +95,9 @@ jobs:
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push B1Admin
+        # NOTE: B1Admin REACT_APP_* vars are baked into the JS bundle at build time (Vite define).
+        # These images are therefore environment-specific (b1-test URLs).
+        # For a different environment, rebuild with different REACT_APP_* build-args.
         uses: docker/build-push-action@v5
         with:
           context: .
@@ -206,6 +213,9 @@ jobs:
             ```
 
             Also tagged `:${{ steps.tag.outputs.sha_tag }}` and `:latest`.
+
+            > **Note:** B1Admin images have b1-test API URLs baked in at build time.
+            > To deploy to a different environment, rebuild with the appropriate `REACT_APP_*` build-args.
 
             ## Upstream submodule commits
 

--- a/.github/workflows/update-submodules.yml
+++ b/.github/workflows/update-submodules.yml
@@ -2,9 +2,15 @@ name: Update Submodules
 
 on:
   schedule:
-    # Every Monday 05:00 UTC — runs before build-images.yml at 06:00
+    # Every Monday 05:00 UTC — runs before build-images.yml at 06:00.
+    # Opens a PR; build-images.yml fires when that PR is merged to main.
     - cron: '0 5 * * 1'
   workflow_dispatch:
+
+# Only one submodule-update run at a time; skip if one is already queued.
+concurrency:
+  group: update-submodules
+  cancel-in-progress: false
 
 jobs:
   update:
@@ -18,7 +24,9 @@ jobs:
         uses: actions/checkout@v4
         with:
           submodules: recursive
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Use PAT so the resulting PR can trigger build-images.yml on merge.
+          # GITHUB_TOKEN-created PRs do NOT trigger other workflow runs.
+          token: ${{ secrets.GH_PAT }}
 
       - name: Update submodules to upstream HEAD
         id: update
@@ -53,7 +61,9 @@ jobs:
         if: steps.update.outputs.changed == 'true'
         uses: peter-evans/create-pull-request@v6
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+          # Must use PAT — GITHUB_TOKEN PRs don't trigger build-images.yml on merge.
+          # Create a classic PAT with repo scope and add it as a repository secret named GH_PAT.
+          token: ${{ secrets.GH_PAT }}
           branch: chore/update-submodules
           commit-message: "chore: update submodules to upstream main"
           title: "chore: weekly submodule update"


### PR DESCRIPTION
## Summary

- **Date tags**: Images pushed as `:YYYYMMDD` + `:<sha7>` + `:latest` on every build
- **GitHub releases**: After all 3 builds pass, a release is created tagged `YYYYMMDD` with image refs, upstream submodule SHAs, and a ready-to-paste \`helm upgrade\` command
- **Weekly submodule PRs**: \`update-submodules.yml\` runs Monday 05:00 UTC, opens a PR if any upstream \`main\` moved, with a per-service \`old → new\` SHA changelog. Merging that PR triggers the build → new dated release published automatically
- **Concurrency**: Both workflows use a \`concurrency:\` group to prevent overlapping runs

## Design decisions

**B1Admin images are environment-specific.** Vite bakes \`REACT_APP_*\` vars into the JS bundle at build time (not runtime). The images produced by this CI have b1-test URLs baked in. To deploy to a different environment, rebuild passing the appropriate \`REACT_APP_*\` build-args. This is documented in comments at the build step and in the GitHub Release body.

**PAT required for submodule PRs.** \`peter-evans/create-pull-request\` with \`GITHUB_TOKEN\` creates PRs that GitHub will not allow to trigger other workflows on merge (by design, to prevent infinite loops). We need the update→merge→build pipeline to fire, so the action requires a classic PAT with \`repo\` scope stored as the \`GH_PAT\` repository secret. Both the checkout token and the PR-creation token must use this PAT.

## Setup required before first run

1. Create a classic PAT (Settings → Developer settings → Personal access tokens → Tokens classic) with **repo** scope
2. Add it as a repository secret: **Settings → Secrets → Actions → New repository secret**, name: \`GH_PAT\`

Without \`GH_PAT\`, \`update-submodules.yml\` will fail at checkout (since the token is required). \`build-images.yml\` is unaffected — it uses \`GITHUB_TOKEN\` throughout (push to GHCR + create release work fine with it).

## Test plan

- [ ] Trigger \`build-images.yml\` via workflow_dispatch — confirm 3 images pushed to ghcr.io and a GitHub release created
- [ ] Add \`GH_PAT\` secret, then trigger \`update-submodules.yml\` via workflow_dispatch — confirm a PR is opened (or "No submodule changes" if upstream hasn't moved)
- [ ] Merge the submodule PR — confirm \`build-images.yml\` fires automatically

🤖 Generated with [Claude Code](https://claude.com/claude-code)