### PR TITLE
fix(helm): b1app TCP probe + correct imageRegistry default

### DIFF
--- a/helm/b1stack/README.md
+++ b/helm/b1stack/README.md
@@ -72,7 +72,7 @@ kubectl --context hetzner-ledo -n b1-test exec -it \
 
 | Key | Default | Description |
 |-----|---------|-------------|
-| `global.imageRegistry` | `registry.bitnami.com` | Override to use Bitnami's own registry (no Docker Hub rate limits). Set to `""` to use Docker Hub. |
+| `global.imageRegistry` | `""` (Docker Hub) | Override to pull from a custom registry / pull-through cache. Leave empty for Docker Hub. Note: `registry.bitnami.com` is a commercial registry — not suitable here. |
 | `global.imagePullSecrets` | `[]` | Secrets added to every pod's `imagePullSecrets` |
 | `global.storageClass` | `""` | Storage class for MySQL PVC. Empty = cluster default (`gp2` on EKS, `standard` on GKE, `hcloud-volumes` on Hetzner). |
 
@@ -316,13 +316,12 @@ api:
 
 ## Docker Hub rate limits
 
-The Bitnami MySQL sub-chart pulls from Docker Hub by default. To avoid rate limit errors, `global.imageRegistry` is set to `registry.bitnami.com` (Bitnami's own registry, no rate limits) out of the box.
+The Bitnami MySQL sub-chart pulls from Docker Hub by default. `global.imageRegistry` is empty by default — images come from Docker Hub.
 
-To revert to Docker Hub (not recommended for production):
-```yaml
-global:
-  imageRegistry: ""
-```
+To avoid Docker Hub rate limits in production, configure a pull-through cache at the cluster level:
+- **k3s**: Add a containerd mirror in `/etc/rancher/k3s/registries.yaml`
+- **EKS**: Use ECR pull-through cache
+- **GKE**: Use Artifact Registry remote repositories
 
 ---
 

--- a/helm/b1stack/templates/b1app-deployment.yaml
+++ b/helm/b1stack/templates/b1app-deployment.yaml
@@ -58,15 +58,17 @@ spec:
             {{- end }}
           resources:
             {{- toYaml .Values.b1app.resources | nindent 12 }}
+          # TCP probe: Next.js SSR on "/" can take >1s to respond (triggers metadata
+          # warnings, data fetches, etc.) causing httpGet probes to time out.
+          # TCP check verifies the port is bound and accepting connections — sufficient
+          # for liveness/readiness without triggering a full page render.
           readinessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: {{ .Values.b1app.service.port }}
             initialDelaySeconds: 15
             periodSeconds: 10
           livenessProbe:
-            httpGet:
-              path: /
+            tcpSocket:
               port: {{ .Values.b1app.service.port }}
             initialDelaySeconds: 30
             periodSeconds: 30

--- a/helm/b1stack/values.yaml
+++ b/helm/b1stack/values.yaml
@@ -25,11 +25,13 @@ mysql:
       FLUSH PRIVILEGES;
 
 # Global settings shared across all sub-charts (including Bitnami MySQL).
-# imageRegistry: Override to pull Bitnami images from their own registry instead of Docker Hub,
-#   avoiding Docker Hub pull rate limits.
-#   Use "registry.bitnami.com" (no rate limits) instead of the default "docker.io".
+# imageRegistry: Override to pull all images from a custom registry (e.g. a pull-through cache).
+#   Leave empty to use Docker Hub (default for Bitnami charts).
+#   Note: registry.bitnami.com is Bitnami's commercial/authenticated registry — not suitable here.
+#   To avoid Docker Hub rate limits in production, configure a pull-through cache at the cluster level
+#   (k3s containerd mirrors, ECR pull-through cache, or GCP Artifact Registry remote repos).
 global:
-  imageRegistry: "registry.bitnami.com"
+  imageRegistry: ""
   imagePullSecrets: []
   # storageClass: "" uses the cluster default (gp2 on EKS, standard on GKE, hcloud-volumes on Hetzner).
   # Override per-environment in values.<env>.yaml.


### PR DESCRIPTION
Two deploy-blocking bugs found during real b1-test deploy:

**1. b1app CrashLoopBackOff** — httpGet liveness probe on `/` times out (Next.js SSR takes >1s; default timeoutSeconds=1). Pod gets SIGTERM after 3 failures → clean exit 0 → CrashLoopBackOff. Fixed by switching to tcpSocket probe.

**2. MySQL ImagePullBackOff** — `global.imageRegistry: "registry.bitnami.com"` was wrong. That is Bitnami's commercial registry; the specific tags used by the Helm chart aren't available there without authentication. Reverted to `""` (Docker Hub default). Operators should use cluster-level pull-through caches (k3s containerd mirrors, ECR, GCR) to avoid Docker Hub rate limits.