### PR TITLE
feat: auto initdb Job + auto-derive DB connection strings

### DIFF
--- a/docker/api/Dockerfile.prod
+++ b/docker/api/Dockerfile.prod
@@ -10,10 +10,13 @@ RUN npm run build:prod
 FROM node:22-alpine AS runner
 WORKDIR /app
 ENV NODE_ENV=production
+# mysql-client: used by the Helm initdb Job (initdb.sh) to create DB schemas on first deploy.
+RUN apk add --no-cache mysql-client
 COPY services/Api/package.json services/Api/package-lock.json ./
 RUN npm ci --omit=dev
 COPY --from=builder /app/dist ./dist
 COPY services/Api/config/ ./config/
 COPY services/Api/tools/ ./tools/
+COPY docker/api/initdb.sh ./initdb.sh
 EXPOSE 8084 8087
 CMD ["node", "dist/index.js"]

--- a/docker/api/initdb.sh
+++ b/docker/api/initdb.sh
@@ -1,0 +1,52 @@
+#!/bin/sh
+# B1Stack database initialisation script.
+# Runs all SQL scripts in tools/dbScripts/ against the bundled MySQL instance.
+#
+# Environment variables:
+#   MYSQL_HOST     - MySQL hostname          (default: b1stack-mysql)
+#   MYSQL_USER     - MySQL username          (default: b1stack)
+#   MYSQL_PASSWORD - MySQL password          (required)
+#   MYSQL_PORT     - MySQL port              (default: 3306)
+
+set -e
+
+HOST="${MYSQL_HOST:-b1stack-mysql}"
+USER="${MYSQL_USER:-b1stack}"
+PORT="${MYSQL_PORT:-3306}"
+
+if [ -z "$MYSQL_PASSWORD" ]; then
+  echo "ERROR: MYSQL_PASSWORD is required" >&2
+  exit 1
+fi
+
+CMD="mysql -h $HOST -P $PORT -u $USER -p${MYSQL_PASSWORD}"
+
+# Wait for MySQL to be ready (up to 5 minutes)
+echo "Waiting for MySQL at $HOST:$PORT ..."
+i=0
+until $CMD -e "SELECT 1" >/dev/null 2>&1; do
+  i=$((i + 1))
+  if [ $i -ge 60 ]; then
+    echo "ERROR: MySQL not ready after 5 minutes." >&2
+    exit 1
+  fi
+  echo "  Not ready yet, retrying in 5s... ($i/60)"
+  sleep 5
+done
+echo "MySQL is ready."
+
+# Run SQL files for each module.
+# --force continues on errors (handles FK ordering); tables are idempotent
+# (DROP TABLE IF EXISTS + CREATE TABLE) so re-runs are safe.
+for module in membership attendance content giving messaging doing reporting; do
+  dir="/app/tools/dbScripts/$module"
+  [ -d "$dir" ] || continue
+  echo "Initialising module: $module"
+  for sql_file in "$dir"/*.sql; do
+    [ -f "$sql_file" ] || continue
+    $CMD --force "$module" < "$sql_file" 2>&1 | grep -v "Warning" || true
+  done
+  echo "  done."
+done
+
+echo "Database initialisation complete."

--- a/helm/b1stack/templates/NOTES.txt
+++ b/helm/b1stack/templates/NOTES.txt
@@ -11,13 +11,20 @@ B1Stack deployed successfully!
   B1App:   {{ if .Values.b1app.ingress.tls }}https{{ else }}http{{ end }}://{{ .Values.b1app.ingress.hostname }}
 {{- end }}
 
-== First-time setup ==
-After initial deploy, run database migrations:
-
-  kubectl -n {{ .Release.Namespace }} exec -it \
-    $(kubectl -n {{ .Release.Namespace }} get pod -l app={{ .Release.Name }}-api \
-      -o jsonpath='{.items[0].metadata.name}') \
-    -- npm run initdb
+== Database migrations ==
+{{- if and .Values.mysql.enabled .Values.initdb.enabled }}
+✓ Automatic: the initdb Job runs on every install/upgrade (Helm post hook).
+  Check status:
+    kubectl -n {{ .Release.Namespace }} get jobs -l app={{ .Release.Name }}-initdb
+    kubectl -n {{ .Release.Namespace }} logs job/{{ .Release.Name }}-initdb-{{ .Release.Revision }}
+{{- else }}
+  initdb Job is disabled (initdb.enabled=false or mysql.enabled=false).
+  Run manually:
+    kubectl -n {{ .Release.Namespace }} exec -it \
+      $(kubectl -n {{ .Release.Namespace }} get pod -l app={{ .Release.Name }}-api \
+        -o jsonpath='{.items[0].metadata.name}') \
+      -- sh /app/initdb.sh
+{{- end }}
 
 == Verify deployment ==
   kubectl -n {{ .Release.Namespace }} get pods

--- a/helm/b1stack/templates/_helpers.tpl
+++ b/helm/b1stack/templates/_helpers.tpl
@@ -13,3 +13,27 @@ helm.sh/chart: {{ .Chart.Name }}-{{ .Chart.Version }}
 app.kubernetes.io/managed-by: {{ .Release.Service }}
 app.kubernetes.io/instance: {{ .Release.Name }}
 {{- end }}
+
+{{/*
+Resolve a DB connection string.
+Usage: include "b1stack.connStr" (list "membership" . .Values.api.secrets.MEMBERSHIP_CONNECTION_STRING)
+  - When mysql.enabled=true and no manual override, auto-computes from mysql.auth values.
+  - Manual override (even empty string skipped; use "mysql://..." to override).
+  - When mysql.enabled=false, the explicit value is required.
+*/}}
+{{- define "b1stack.connStr" -}}
+{{- $module   := index . 0 -}}
+{{- $ctx      := index . 1 -}}
+{{- $override := index . 2 -}}
+{{- if $override -}}
+  {{- $override -}}
+{{- else if $ctx.Values.mysql.enabled -}}
+  {{- printf "mysql://%s:%s@%s-mysql:3306/%s"
+        $ctx.Values.mysql.auth.username
+        $ctx.Values.mysql.auth.password
+        $ctx.Release.Name
+        $module -}}
+{{- else -}}
+  {{- required (printf "api.secrets.%s_CONNECTION_STRING is required when mysql.enabled=false" (upper $module)) $override -}}
+{{- end -}}
+{{- end }}

--- a/helm/b1stack/templates/api-initdb-job.yaml
+++ b/helm/b1stack/templates/api-initdb-job.yaml
@@ -1,0 +1,58 @@
+{{- if and .Values.api.enabled .Values.mysql.enabled .Values.initdb.enabled }}
+# Helm hook Job: runs DB schema initialisation after every install or upgrade.
+# Uses the API image (which contains tools/dbScripts/*.sql and docker/api/initdb.sh).
+# Safe to re-run: SQL scripts use DROP TABLE IF EXISTS + CREATE TABLE.
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ .Release.Name }}-initdb-{{ .Release.Revision }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app: {{ .Release.Name }}-initdb
+  annotations:
+    "helm.sh/hook": post-install,post-upgrade
+    "helm.sh/hook-weight": "0"
+    "helm.sh/hook-delete-policy": {{ .Values.initdb.hookDeletePolicy | quote }}
+spec:
+  backoffLimit: {{ .Values.initdb.backoffLimit }}
+  activeDeadlineSeconds: {{ .Values.initdb.activeDeadlineSeconds }}
+  template:
+    metadata:
+      labels:
+        app: {{ .Release.Name }}-initdb
+    spec:
+      restartPolicy: OnFailure
+      {{- if or .Values.api.imagePullSecrets .Values.global.imagePullSecrets }}
+      imagePullSecrets:
+        {{- range .Values.global.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+        {{- range .Values.api.imagePullSecrets }}
+        - name: {{ . }}
+        {{- end }}
+      {{- end }}
+      containers:
+        - name: initdb
+          image: "{{ .Values.api.image.repository }}:{{ .Values.api.image.tag }}"
+          imagePullPolicy: {{ .Values.api.image.pullPolicy }}
+          command: ["/bin/sh", "/app/initdb.sh"]
+          env:
+            - name: MYSQL_HOST
+              value: {{ .Release.Name }}-mysql
+            - name: MYSQL_USER
+              value: {{ .Values.mysql.auth.username | quote }}
+            - name: MYSQL_PORT
+              value: "3306"
+            - name: MYSQL_PASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: {{ .Release.Name }}-mysql
+                  key: mysql-password
+          resources:
+            requests:
+              cpu: 50m
+              memory: 64Mi
+            limits:
+              cpu: 200m
+              memory: 128Mi
+{{- end }}

--- a/helm/b1stack/templates/api-secret.yaml
+++ b/helm/b1stack/templates/api-secret.yaml
@@ -10,7 +10,30 @@ metadata:
     app: {{ .Release.Name }}-api
 type: Opaque
 stringData:
+  # ── Required ──────────────────────────────────────────────────────────────
+  ENCRYPTION_KEY: {{ required "api.secrets.ENCRYPTION_KEY is required" .Values.api.secrets.ENCRYPTION_KEY | quote }}
+  JWT_SECRET: {{ required "api.secrets.JWT_SECRET is required" .Values.api.secrets.JWT_SECRET | quote }}
+
+  # ── Database connection strings ────────────────────────────────────────────
+  # When mysql.enabled=true these are auto-derived from mysql.auth credentials.
+  # Set api.secrets.*_CONNECTION_STRING explicitly to override (e.g. external DB).
+  MEMBERSHIP_CONNECTION_STRING: {{ include "b1stack.connStr" (list "membership"  . .Values.api.secrets.MEMBERSHIP_CONNECTION_STRING)  | quote }}
+  ATTENDANCE_CONNECTION_STRING: {{ include "b1stack.connStr" (list "attendance"  . .Values.api.secrets.ATTENDANCE_CONNECTION_STRING)  | quote }}
+  CONTENT_CONNECTION_STRING:    {{ include "b1stack.connStr" (list "content"     . .Values.api.secrets.CONTENT_CONNECTION_STRING)     | quote }}
+  GIVING_CONNECTION_STRING:     {{ include "b1stack.connStr" (list "giving"      . .Values.api.secrets.GIVING_CONNECTION_STRING)      | quote }}
+  MESSAGING_CONNECTION_STRING:  {{ include "b1stack.connStr" (list "messaging"   . .Values.api.secrets.MESSAGING_CONNECTION_STRING)   | quote }}
+  DOING_CONNECTION_STRING:      {{ include "b1stack.connStr" (list "doing"       . .Values.api.secrets.DOING_CONNECTION_STRING)       | quote }}
+  REPORTING_CONNECTION_STRING:  {{ include "b1stack.connStr" (list "reporting"   . .Values.api.secrets.REPORTING_CONNECTION_STRING)   | quote }}
+
+  # ── Optional secrets (included only when set) ─────────────────────────────
   {{- range $k, $v := .Values.api.secrets }}
+  {{- if and $v (not (has $k (list
+        "ENCRYPTION_KEY" "JWT_SECRET"
+        "MEMBERSHIP_CONNECTION_STRING" "ATTENDANCE_CONNECTION_STRING"
+        "CONTENT_CONNECTION_STRING" "GIVING_CONNECTION_STRING"
+        "MESSAGING_CONNECTION_STRING" "DOING_CONNECTION_STRING"
+        "REPORTING_CONNECTION_STRING"))) }}
   {{ $k }}: {{ $v | quote }}
+  {{- end }}
   {{- end }}
 {{- end }}

--- a/helm/b1stack/values.b1-test.yaml
+++ b/helm/b1stack/values.b1-test.yaml
@@ -1,23 +1,27 @@
 # B1-Test environment overrides for hz.ledoweb.com
 #
-# Deploy:
+# Deploy (connection strings auto-derived from mysql.auth.password when mysql.enabled=true):
 #   helm upgrade --install b1stack helm/b1stack \
 #     --kube-context hetzner-ledo --namespace b1-test --create-namespace \
 #     -f helm/b1stack/values.yaml -f helm/b1stack/values.b1-test.yaml \
+#     --set mysql.image.registry=public.ecr.aws \
+#     --set mysql.image.repository=bitnami/mysql \
+#     --set global.security.allowInsecureImages=true \
 #     --set mysql.auth.rootPassword=<ROOT_PW> \
 #     --set mysql.auth.password=<APP_PW> \
 #     --set api.secrets.ENCRYPTION_KEY=<24_CHAR_KEY> \
 #     --set api.secrets.JWT_SECRET=<SECRET> \
-#     --set "api.secrets.MEMBERSHIP_CONNECTION_STRING=mysql://b1stack:<APP_PW>@b1stack-mysql:3306/membership" \
-#     --set "api.secrets.ATTENDANCE_CONNECTION_STRING=mysql://b1stack:<APP_PW>@b1stack-mysql:3306/attendance" \
-#     --set "api.secrets.CONTENT_CONNECTION_STRING=mysql://b1stack:<APP_PW>@b1stack-mysql:3306/content" \
-#     --set "api.secrets.GIVING_CONNECTION_STRING=mysql://b1stack:<APP_PW>@b1stack-mysql:3306/giving" \
-#     --set "api.secrets.MESSAGING_CONNECTION_STRING=mysql://b1stack:<APP_PW>@b1stack-mysql:3306/messaging" \
-#     --set "api.secrets.DOING_CONNECTION_STRING=mysql://b1stack:<APP_PW>@b1stack-mysql:3306/doing" \
-#     --set "api.secrets.REPORTING_CONNECTION_STRING=mysql://b1stack:<APP_PW>@b1stack-mysql:3306/reporting" \
 #     --wait --timeout 10m
 
 mysql:
+  # Bitnami removed all tags from Docker Hub; use AWS ECR Public as a free mirror.
+  # See: https://github.com/bitnami/charts/issues/29947
+  image:
+    registry: public.ecr.aws
+    repository: bitnami/mysql
+  global:
+    security:
+      allowInsecureImages: true
   primary:
     persistence:
       storageClass: hcloud-volumes

--- a/helm/b1stack/values.yaml
+++ b/helm/b1stack/values.yaml
@@ -119,15 +119,18 @@ api:
     ENCRYPTION_KEY: "CHANGE_ME"
     JWT_SECRET: "CHANGE_ME"
 
-    # Database — one connection string per module.
-    # When mysql.enabled=false, point these at your external DB (Cloud SQL, RDS, etc.)
-    MEMBERSHIP_CONNECTION_STRING: "mysql://b1stack:CHANGE_ME@b1stack-mysql:3306/membership"
-    ATTENDANCE_CONNECTION_STRING: "mysql://b1stack:CHANGE_ME@b1stack-mysql:3306/attendance"
-    CONTENT_CONNECTION_STRING: "mysql://b1stack:CHANGE_ME@b1stack-mysql:3306/content"
-    GIVING_CONNECTION_STRING: "mysql://b1stack:CHANGE_ME@b1stack-mysql:3306/giving"
-    MESSAGING_CONNECTION_STRING: "mysql://b1stack:CHANGE_ME@b1stack-mysql:3306/messaging"
-    DOING_CONNECTION_STRING: "mysql://b1stack:CHANGE_ME@b1stack-mysql:3306/doing"
-    REPORTING_CONNECTION_STRING: "mysql://b1stack:CHANGE_ME@b1stack-mysql:3306/reporting"
+    # Database — connection strings per module.
+    # When mysql.enabled=true (default), these are AUTO-DERIVED from mysql.auth
+    # credentials — you do NOT need to set them here.
+    # When mysql.enabled=false, set each to point at your external DB:
+    #   mysql://user:pass@host:3306/dbname
+    MEMBERSHIP_CONNECTION_STRING: ""
+    ATTENDANCE_CONNECTION_STRING: ""
+    CONTENT_CONNECTION_STRING: ""
+    GIVING_CONNECTION_STRING: ""
+    MESSAGING_CONNECTION_STRING: ""
+    DOING_CONNECTION_STRING: ""
+    REPORTING_CONNECTION_STRING: ""
 
     # ── Optional secrets (uncomment and set as needed) ────────────────────────
     # File storage (required when FILE_STORE=S3)
@@ -322,6 +325,20 @@ lessonsapi:
     targetCPUUtilizationPercentage: 60
     targetMemoryUtilizationPercentage: 80
 
+# Database initialisation Job (Helm post-install / post-upgrade hook).
+# Runs tools/dbScripts/*.sql against the bundled MySQL to create tables on first
+# install and apply any new schema on upgrades. Safe to re-run (idempotent SQL).
+# Only active when mysql.enabled=true (bundled MySQL).
+initdb:
+  enabled: true
+  # hook-succeeded: delete Job pod after success (keeps cluster clean).
+  # hook-failed: keep Job pod after failure for log inspection.
+  # before-hook-creation: delete old hook Job before creating a new one.
+  hookDeletePolicy: "before-hook-creation,hook-succeeded"
+  # Retry up to 3 times before marking the Job as failed.
+  backoffLimit: 3
+  # Kill the Job after 10 minutes to avoid hanging installs.
+  activeDeadlineSeconds: 600
 # AskApi (optional — enable separately when needed)
 askapi:
   enabled: false


### PR DESCRIPTION
## Summary

- **Auto initdb hook**: Helm `post-install`/`post-upgrade` Job that runs `tools/dbScripts/*.sql` automatically on every install/upgrade — no more manual `kubectl exec` for DB schema
- **Auto DB connection strings**: When `mysql.enabled=true`, all 7 DB connection strings are auto-derived from `mysql.auth.username/password` — users only need 4 `--set` flags instead of 11
- **ECR Public for MySQL image**: Bitnami removed all tags from Docker Hub; `public.ecr.aws/bitnami/mysql` baked into `values.b1-test.yaml` as the free, unauthenticated mirror
- **mysql-client in API image**: Added to `node:alpine` runner stage so the initdb Job can run the shell script

## Out-of-box deploy (was 11 flags, now 4)

```bash
helm upgrade --install b1stack helm/b1stack \
  -f helm/b1stack/values.yaml -f helm/b1stack/values.b1-test.yaml \
  --set mysql.auth.rootPassword=<ROOT_PW> \
  --set mysql.auth.password=<APP_PW> \
  --set api.secrets.ENCRYPTION_KEY=<KEY> \
  --set api.secrets.JWT_SECRET=<SECRET> \
  --wait --timeout 10m
```

## Test plan

- [ ] `helm lint` passes (0 failures)
- [ ] `helm template` renders initdb Job with correct hook annotations
- [ ] Connection strings auto-computed from `mysql.auth.password` in rendered Secret
- [ ] CI build pushes new API image with mysql-client
- [ ] initdb Job runs successfully on next deploy to b1-test cluster